### PR TITLE
Update reports_form.py

### DIFF
--- a/calpads/reports_form.py
+++ b/calpads/reports_form.py
@@ -155,7 +155,7 @@ class ReportsForm:
                         continue
                     to_submit[formname] = formval
                 elif self.complete_parse[paramname][1][0] in ('textbox', 'textbox_defaultnull'): #TODO: defaultnull still needs testing
-                    formname = self.complete_parse[paramname][1][1]
+                    formname = self.complete_parse[paramname][1][1][1]
                     to_submit[formname] = paramvalue
             else:
                 self.log.info("Provided input was not processed: {}".format(paramname))


### PR DESCRIPTION
I found this issue when working with the 8.1a report. An issue arises when trying to use the FromDate and ThrouDate parameters of download_report where the inputted dates do not overwrite the default dates. It seems the function in line 158 was expecting only a key-value pair, but instead three elements get passed in. The second element is 'textbox', which the function does not recognize. Adding the extra [1] selects the third element, which is the date being passed in. This may be related to the Issue titled _ODS and Snapshots Unsupported Field Types #4_.