### PR TITLE
Kipp add four methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # calpads
 An unofficial Python Web API wrapper for California Department of Education's CALPADS.
 
-[Version 0.6.0](https://github.com/SummitPublicSchools/calpads/tree/0.6.0) is pretty great and covers many use-cases. Given its lack of official support, the wrapper is subject to break at any moment if the internals of CALPADS magic change.
+[Version 0.7.0](https://github.com/SummitPublicSchools/calpads/tree/0.7.0) is pretty great and covers many use-cases. Given its lack of official support, the wrapper is subject to break at any moment if the internals of CALPADS magic change.
 
 # We Have Documentation!
 Supported endpoints, downloads, and other features are [documented in our GitBook website](https://summit-public-schools.gitbook.io/calpads-api/).

--- a/calpads/client.py
+++ b/calpads/client.py
@@ -303,6 +303,17 @@ class CALPADSClient:
         response = self.session.get(urljoin(self.host, f'/Student/{ssid}/SPED?format=JSON'))
         return safe_json_load(response)
 
+    def get_swds_history(self, ssid):
+        """Returns a JSON object with the Students with Disabilities Status (SWDS) history for the provided SSID
+        Args:
+            ssid (int, str): the 10 digit CALPADS Statewide Student Identifier
+        Returns:
+            a JSON object with a Data key and a total record count key (the name of this key can vary).
+            Expected data is under Data as a List where each item is a "row" of data
+        """
+        response = self.session.get(urljoin(self.host, f'/Student/{ssid}/SWDS?format=JSON'))
+        return safe_json_load(response)
+
     def get_ssrv_history(self, ssid):
         """Returns a JSON object with the Student Services (SSRV) history for the provided SSID
 

--- a/calpads/client.py
+++ b/calpads/client.py
@@ -316,6 +316,17 @@ class CALPADSClient:
         response = self.session.get(urljoin(self.host, f'/Student/{ssid}/SSRV?format=JSON'))
         return safe_json_load(response)
 
+    def get_meet_history(self, ssid):
+        """Returns a JSON object with the Special Education Meetings (MEET) history for the provided SSID
+        Args:
+            ssid (int, str): the 10 digit CALPADS Statewide Student Identifier
+        Returns:
+            a JSON object with a Data key and a total record count key (the name of this key can vary).
+            Expected data is under Data as a List where each item is a "row" of data
+        """
+        response = self.session.get(urljoin(self.host, f'/Student/{ssid}/MEET?format=JSON'))
+        return safe_json_load(response)
+
     def get_psts_history(self, ssid):
         """Returns a JSON object with the Postsecondary Transition Status (PSTS) history for the provided SSID
 

--- a/calpads/client.py
+++ b/calpads/client.py
@@ -340,6 +340,17 @@ class CALPADSClient:
         response = self.session.get(urljoin(self.host, f'/Student/{ssid}/PSTS?format=JSON'))
         return safe_json_load(response)
 
+    def get_plan_history(self, ssid):
+        """Returns a JSON object with the Special Education Plans (PLAN) history for the provided SSID
+        Args:
+            ssid (int, str): the 10 digit CALPADS Statewide Student Identifier
+        Returns:
+            a JSON object with a Data key and a total record count key (the name of this key can vary).
+            Expected data is under Data as a List where each item is a "row" of data
+        """
+        response = self.session.get(urljoin(self.host, f'/Student/{ssid}/PLAN?format=JSON'))
+        return safe_json_load(response)
+
     def get_requested_extracts(self, lea_code):
         """Returns a dictionary object with the a list of extracts at the provided lea_code
 

--- a/calpads/client.py
+++ b/calpads/client.py
@@ -303,6 +303,17 @@ class CALPADSClient:
         response = self.session.get(urljoin(self.host, f'/Student/{ssid}/SPED?format=JSON'))
         return safe_json_load(response)
 
+    def get_serv_history(self, ssid):
+        """Returns a JSON object with the Special Education Services (SERV) history for the provided SSID
+        Args:
+            ssid (int, str): the 10 digit CALPADS Statewide Student Identifier
+        Returns:
+            a JSON object with a Data key and a total record count key (the name of this key can vary).
+            Expected data is under Data as a List where each item is a "row" of data
+        """
+        response = self.session.get(urljoin(self.host, f'/Student/{ssid}/SERV?format=JSON'))
+        return safe_json_load(response)
+
     def get_swds_history(self, ssid):
         """Returns a JSON object with the Students with Disabilities Status (SWDS) history for the provided SSID
         Args:

--- a/calpads/client.py
+++ b/calpads/client.py
@@ -291,7 +291,7 @@ class CALPADSClient:
         return safe_json_load(response)
 
     def get_sped_history(self, ssid):
-        """Returns a JSON object with the Special Education (SPED) history for the provided SSID
+        """Returns a JSON object with the Student Special Education Archive (SPED) history for the provided SSID
 
         Args:
             ssid (int, str): the 10 digit CALPADS Statewide Student Identifier
@@ -326,7 +326,7 @@ class CALPADSClient:
         return safe_json_load(response)
 
     def get_ssrv_history(self, ssid):
-        """Returns a JSON object with the Student Services (SSRV) history for the provided SSID
+        """Returns a JSON object with the Student Special Education Services Archive (SSRV) history for the provided SSID
 
         Args:
             ssid (int, str): the 10 digit CALPADS Statewide Student Identifier


### PR DESCRIPTION
Added two new methods to Client class.

- **get_meet_history** - Gets SPED meeting history for student using SSID
- **get_plan_history** - Gets Postsecondary Transition Status history for student using SSID
- **get_serv_history** - Gets Special Education Archive (SPED) history for the provided SSID
- **get_swds_history** - Gets Students with Disabilities Status (SWDS) history for the provided SSID

These methods are essentially the same other methods (i.e. get_ssrv_history) and are just pulling JSON data from a link. All have been tested and are working.